### PR TITLE
Fixing raw bytes output in test_sensor.ino

### DIFF
--- a/test_sensors/test_sensors.ino
+++ b/test_sensors/test_sensors.ino
@@ -238,20 +238,23 @@ void loop() {
     }
   }
   else if (testIndex == 2) { // testing camera
-    Camera.readFrame(image);
     if (printFlag) {
       if (liveFlag) {
+        Camera.readFrame(image);
         Serial.write(image, bytesPerFrame);
-        delay(1000);
       }
       else {
         if (captureFlag) {
           captureFlag = false;
-          Serial.print("0x");
-          Serial.print(image[0], HEX);
-          for (int i = 1; i < bytesPerFrame; i++) {
-            Serial.print(", 0x");
+          Camera.readFrame(image);
+          delay(3000);
+          for (int i = 0; i < bytesPerFrame - 1; i += 2) {
+            Serial.print("0x");
+            Serial.print(image[i+1], HEX);
             Serial.print(image[i], HEX);
+            if (i != bytesPerFrame - 2) {
+              Serial.print(", ");
+            }
           }
           Serial.println();
         }


### PR DESCRIPTION
test_sensor.ino would output each byte at a time but it's much easier to output 2 bytes since RGB565 uses 2 bytes per pixel.

The code for the camera is taken from test_camera.ino which I confirmed worked properly.